### PR TITLE
Allow PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "worldpay/magento2-module-payments",
     "description": "Worldpay Payments",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
         "magento/magento-composer-installer": "*",
         "magento/module-sales": "*",
         "magento/module-payment": "*",


### PR DESCRIPTION
PHP 7.1 is becoming more standard. As it currently stands you can't composer require this project with any version above 7.0