### PR TITLE
Fix unserialization of sitecodes config

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,6 +1,8 @@
 <?php
 namespace Worldpay\Payments\Model;
 
+use Magento\Framework\Serialize\Serializer\Json as Serialize;
+
 class Config
 {
     /**
@@ -9,15 +11,22 @@ class Config
     protected $_scopeConfigInterface;
     protected $customerSession;
 
+    /**
+     * @var Serialize
+     */
+    private $serialize;
+
     public function __construct(
     \Magento\Framework\App\Config\ScopeConfigInterface $configInterface,
     \Magento\Customer\Model\Session $customerSession,
-    \Magento\Backend\Model\Session\Quote $sessionQuote
+    \Magento\Backend\Model\Session\Quote $sessionQuote,
+    Serialize $serialize
     )
     {
         $this->_scopeConfigInterface = $configInterface;
         $this->customerSession = $customerSession;
         $this->sessionQuote = $sessionQuote;
+        $this->serialize = $serialize;
     }
 
     public function isLiveMode() {
@@ -77,7 +86,7 @@ class Config
     public function getSitecodes() {
         $sitecodeConfig = $this->_scopeConfigInterface->getValue('payment/worldpay_payments_card/sitecodes');
         if ($sitecodeConfig) {
-            $siteCodes = unserialize($sitecodeConfig);
+            $siteCodes = $this->serialize->unserialize($sitecodeConfig);
             if (is_array($siteCodes)) {
                 return $siteCodes;
             }


### PR DESCRIPTION
In Magento 2.2x the method of general serialization was changed. A new class is used for both serialization and unserialization:

`Magento\Framework\Serialize\Serializer\Json`

You use the core model for you Backend Model for the system configuration of SiteCodes:

`Magento\Config\Model\Config\Backend\Serialized\ArraySerialized`

This uses the new Magento Serialization upon save and therefore needs to use the new method of unserialization otherwise a fatal error is thrown.

Maybe for backwards compatibility you should write and use your own BackendModel instead of the core, which simply extends the core and uses the native PHP serialize/unserialize methods. 

Either way this needs a fix of some sort. Anyone using the extension on a fresh Magento 2.2+ will be getting a fatal error on the checkout when trying to place order. 